### PR TITLE
redirect tty output to browser in demo shell

### DIFF
--- a/demos/shell/shell1.css
+++ b/demos/shell/shell1.css
@@ -1,14 +1,14 @@
 body {margin-left:100px;
       border-radius:10px;
       padding:1em;
-      width:320px;
-      height:260px;
+      width:920px;
+      height:520px;
       border: 2px solid black;
       box-shadow:black 0.2em 0.2em 0.2em;
      }
 
-#scroll{height:10em;
-	width:300px;
+#scroll{height:20em;
+	width:900px;
 	font-family: "Courier New", Courier, monospace;
 	font-weight:bold;
 	background-color:#efefef;
@@ -18,7 +18,7 @@ body {margin-left:100px;
 	border-radius: 10px;
        }
 
-#input { width:320px;
+#input { width:920px;
 	box-shadow:black 0.1em 0.1em 0.1em;
 	border-radius: 2px;
 }

--- a/demos/shell/shell1.erl
+++ b/demos/shell/shell1.erl
@@ -6,15 +6,22 @@ start(Browser) ->
     Browser ! [{cmd,append_div}, {id, scroll}, 
 	       {txt, <<"Starting Erlang shell yes<br>">>}],
     B0 = erl_eval:new_bindings(),
-    running(Browser, B0, 1).
+    IO = grab_io(),
+    running(Browser, IO, B0, 1).
 
-running(Browser, B0, N) ->
+running(Browser, IO, B0, N) ->
     receive
 	{Browser, {struct, [{entry,<<"input">>},{txt, Bin}]}} ->
+	    Echo = bf("~w > <font color='red'>~s</font><br>", [N, Bin]),
+	    Browser ! [{cmd,append_div},{id, scroll}, {txt, Echo}],
 	    {Value, B1} = string2value(binary_to_list(Bin), B0),
-	    BV = bf("~w > <font color='red'>~s</font><br>~p<br>", [N, Bin, Value]),
+	    BV = bf("~p<br>", [Value]),
 	    Browser ! [{cmd,append_div},{id, scroll}, {txt, BV}],
-	    running(Browser, B1, N+1)
+	    running(Browser, IO, B1, N+1);
+	{IO, {output, Bin}} ->
+	    Browser ! [{cmd, append_div}, {id,scroll},
+		       {txt, <<"<pre>", Bin/binary, "</pre><br>">>}],
+	    running(Browser, IO, B0, N)
     end.
 %%END:shell1
 
@@ -37,4 +44,62 @@ string2value(Str, Bindings0) ->
 
 bf(F, D) ->
     list_to_binary(io_lib:format(F, D)).
+
+grab_io() ->
+    P = self(),
+    spawn(fun() ->
+		  group_leader(self(), P),
+		  _ = erlang:monitor(process, P),
+		  io_loop(P)
+	  end).
+
+io_loop(P) ->
+    receive
+	{io_request,From,ReplyAs,Req} when is_pid(From) ->
+	    Res = io_request(Req, P),
+	    io_reply(From, ReplyAs, Res),
+	    io_loop(P);
+	{'DOWN',_,process,P,_} ->
+	    exit(normal)
+    end.
+
+io_request({put_chars, unicode, Binary}, P) when is_binary(Binary) ->
+    output(P, Binary);
+io_request({put_chars, unicode, M, F, As}, P) ->
+    case catch apply(M, F, As) of
+        Binary when is_binary(Binary) ->
+	    output(P, Binary);
+        Chars ->
+            case catch unicode:characters_to_binary(Chars,utf8) of
+                B when is_binary(B) ->
+                    output(P, B);
+                _ ->
+                    {error,{error,F}}
+            end
+    end;
+io_request({put_chars, latin1, Chars}, P) ->
+    output(P, unicode:characters_to_binary(Chars, latin1));
+io_request({put_chars, latin1, M, F, As}, P) ->
+    case catch apply(M, F, As) of
+        Binary when is_binary(Binary) ->
+            output(P, unicode:characters_to_binary(Binary,latin1)),
+	    ok;
+        Chars ->
+            case catch unicode:characters_to_binary(Chars,latin1) of
+                B when is_binary(B) ->
+		    output(P, B);
+                _ ->
+                    {error,{error,F}}
+            end
+    end;
+io_request(_, _) ->
+    {error, not_supported}.
+
+output(P, Cs) ->
+    P ! {self(), {output, Cs}},
+    ok.
+
+io_reply(From, ReplyAs, Reply) ->
+    From ! {io_reply,ReplyAs,Reply}.
+
 


### PR DESCRIPTION
First thing I tried with the shell demo was to enter `c:regs()`, which resulted in output in the real erlang shell, but not much in the browser.

This patch spawns a small group_leader process which collects IO generated by the evaluated command and sends it to the browser. The browser-side output is currently pretty ugly. I'll gladly leave that to some HTML/JS wiz to fix. :)
