### PR TITLE
Update Makefile to grab dependencies if missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 all:
+	@test -d deps || rebar get-deps	
 	rebar compile
 	cd demos; make


### PR DESCRIPTION
Since these are mostly toy examples for beginners, 
I felt they shouldn't have to know to type rebar get-deps to play with them.
