### PR TITLE
Fixes in the starting of dependencies and loading of index.html from priv_dir

### DIFF
--- a/src/ezwebframe.erl
+++ b/src/ezwebframe.erl
@@ -9,7 +9,8 @@
 	 websocket_info/3,
 	 append_div/3,
 	 pre/1,
-	 fill_div/3
+	 fill_div/3,
+	 start_if_not_running/1
 	]).
 
 -import(ezwebframe_mochijson2, [encode/1, decode/1]).
@@ -20,8 +21,8 @@
 -record(env, {dispatch}).
 
 start_embedded(Port) ->
-    ok   = application:start(ranch),
-    ok   = application:start(cowboy),
+    ok   = start_if_not_running(ranch),
+    ok   = start_if_not_running(cowboy),
     web_server_start(Port, "zip"),
     receive
 	after 
@@ -36,9 +37,9 @@ start_link([PortAtom, DirAtom]) ->
     start_link(Dir, Port).
 
 start_link(Dispatch, Port) ->
-    ok = application:start(crypto),
-    ok = application:start(ranch),  
-    ok = application:start(cowboy),
+    ok = start_if_not_running(crypto),
+    ok = start_if_not_running(ranch),  
+    ok = start_if_not_running(cowboy),
     ok = web_server_start(Port, Dispatch),
     receive
 	after 
@@ -263,6 +264,11 @@ atomize(L) when is_list(L) ->
 atomize(X) ->
     X.
 
+start_if_not_running(App) ->
+    case application:get_application(App) of
+	{ok, App} -> ok;
+	undefined -> application:start(App)
+    end.
 %%----------------------------------------------------------------------
 %% these are to be called from the gui client code
 

--- a/src/ezwebframe.erl
+++ b/src/ezwebframe.erl
@@ -31,7 +31,6 @@ start_link([PortAtom, DirAtom]) ->
     start_link(Dir, Port).
 
 start_link(Dispatch, Port) ->
-    io:format("starting crypto ranch and cowboy~n"),
     ok = start_if_not_running(crypto),
     ok = start_if_not_running(ranch),  
     ok = start_if_not_running(cowboy),
@@ -39,7 +38,6 @@ start_link(Dispatch, Port) ->
     ok.
     
 web_server_start(Port, Dispatcher) ->
-    io:format("starting webserver ~n"),
     E0 = #env{dispatch=Dispatcher},
     Dispatch = [{'_', [{'_', ?MODULE, E0}]}],  
     %% server is the name of this module

--- a/src/ezwebframe.erl
+++ b/src/ezwebframe.erl
@@ -22,12 +22,7 @@
 start_embedded(Port) ->
     ok   = start_if_not_running(ranch),
     ok   = start_if_not_running(cowboy),
-    web_server_start(Port, "zip"),
-    receive
-	after 
-	    infinity ->
-		true
-	end.
+    web_server_start(Port, "zip").
 
 start_link([PortAtom, DirAtom]) ->
     Port = list_to_integer(atom_to_list(PortAtom)),
@@ -36,33 +31,31 @@ start_link([PortAtom, DirAtom]) ->
     start_link(Dir, Port).
 
 start_link(Dispatch, Port) ->
+    io:format("starting crypto ranch and cowboy~n"),
     ok = start_if_not_running(crypto),
     ok = start_if_not_running(ranch),  
     ok = start_if_not_running(cowboy),
     ok = web_server_start(Port, Dispatch),
-    receive
-	after 
-	    infinity ->
-		true
-	end.
+    ok.
     
 web_server_start(Port, Dispatcher) ->
+    io:format("starting webserver ~n"),
     E0 = #env{dispatch=Dispatcher},
     Dispatch = [{'_', [{'_', ?MODULE, E0}]}],  
     %% server is the name of this module
     NumberOfAcceptors = 100,
     Status = 
-	cowboy:start_http(my_named_thing,
-			  NumberOfAcceptors,
-			  [{port, Port}],
-			  [{dispatch, Dispatch}]),
+    	cowboy:start_http(my_named_thing,
+    			  NumberOfAcceptors,
+    			  [{port, Port}],
+    			  [{dispatch, Dispatch}]),
     case Status of
-	{error, _} ->
-	    io:format("websockets could not be started -- "
-		      "port ~p probably in use~n", [Port]),
-	    init:stop();
-	{ok, _Pid} ->
-	    io:format("websockets started on port:~p~n",[Port])
+    	{error, _} ->
+    	    io:format("websockets could not be started -- "
+    		      "port ~p probably in use~n", [Port]),
+    	    init:stop();
+    	{ok, _Pid} ->
+    	    io:format("websockets started on port:~p~n",[Port])
     end.
 
 init(_, Req, E0) ->   
@@ -90,7 +83,10 @@ handle(Req, Env) ->
     io:format("mapped to:~p~n",[Res1]),
     case Resource of
 	"/" ->
-	    serve_file("index.html", Req, Env);
+	    case filelib:is_file("index.html") of
+		true -> serve_file("index.html", Req, Env);
+		false -> serve_file(Res1,Req,Env)
+	    end;
 	"/files" ->
 	    list_dir(F("/"), Req, Env);
 	_ ->
@@ -264,9 +260,12 @@ atomize(X) ->
     X.
 
 start_if_not_running(App) ->
-    case application:get_application(App) of
-	{ok, App} -> ok;
-	undefined -> application:start(App)
+    Running = [A || {A,_Name,_Version} <- application:which_applications(), A =:= App],
+    case Running of
+	[] -> 
+	    application:start(App);
+	 _ ->
+	    ok
     end.
 %%----------------------------------------------------------------------
 %% these are to be called from the gui client code

--- a/src/ezwebframe.erl
+++ b/src/ezwebframe.erl
@@ -20,14 +20,9 @@
 -record(env, {dispatch}).
 
 start_embedded(Port) ->
-    ok   = application:start(ranch),
-    ok   = application:start(cowboy),
-    web_server_start(Port, "zip"),
-    receive
-	after 
-	    infinity ->
-		true
-	end.
+    ok   = start_if_not_running(ranch),
+    ok   = start_if_not_running(cowboy),
+    web_server_start(Port, "zip").
 
 start_link([PortAtom, DirAtom]) ->
     Port = list_to_integer(atom_to_list(PortAtom)),
@@ -36,33 +31,31 @@ start_link([PortAtom, DirAtom]) ->
     start_link(Dir, Port).
 
 start_link(Dispatch, Port) ->
-    ok = application:start(crypto),
-    ok = application:start(ranch),  
-    ok = application:start(cowboy),
+    io:format("starting crypto ranch and cowboy~n"),
+    ok = start_if_not_running(crypto),
+    ok = start_if_not_running(ranch),  
+    ok = start_if_not_running(cowboy),
     ok = web_server_start(Port, Dispatch),
-    receive
-	after 
-	    infinity ->
-		true
-	end.
+    ok.
     
 web_server_start(Port, Dispatcher) ->
+    io:format("starting webserver ~n"),
     E0 = #env{dispatch=Dispatcher},
     Dispatch = [{'_', [{'_', ?MODULE, E0}]}],  
     %% server is the name of this module
     NumberOfAcceptors = 100,
     Status = 
-	cowboy:start_http(my_named_thing,
-			  NumberOfAcceptors,
-			  [{port, Port}],
-			  [{dispatch, Dispatch}]),
+    	cowboy:start_http(my_named_thing,
+    			  NumberOfAcceptors,
+    			  [{port, Port}],
+    			  [{dispatch, Dispatch}]),
     case Status of
-	{error, _} ->
-	    io:format("websockets could not be started -- "
-		      "port ~p probably in use~n", [Port]),
-	    init:stop();
-	{ok, _Pid} ->
-	    io:format("websockets started on port:~p~n",[Port])
+    	{error, _} ->
+    	    io:format("websockets could not be started -- "
+    		      "port ~p probably in use~n", [Port]),
+    	    init:stop();
+    	{ok, _Pid} ->
+    	    io:format("websockets started on port:~p~n",[Port])
     end.
 
 init(_, Req, E0) ->   
@@ -90,7 +83,10 @@ handle(Req, Env) ->
     io:format("mapped to:~p~n",[Res1]),
     case Resource of
 	"/" ->
-	    serve_file("index.html", Req, Env);
+	    case filelib:is_file("index.html") of
+		true -> serve_file("index.html", Req, Env);
+		false -> serve_file(Res1,Req,Env)
+	    end;
 	"/files" ->
 	    list_dir(F("/"), Req, Env);
 	_ ->
@@ -263,6 +259,14 @@ atomize(L) when is_list(L) ->
 atomize(X) ->
     X.
 
+start_if_not_running(App) ->
+    Running = [A || {A,_Name,_Version} <- application:which_applications(), A =:= App],
+    case Running of
+	[] -> 
+	    application:start(App);
+	 _ ->
+	    ok
+    end.
 %%----------------------------------------------------------------------
 %% these are to be called from the gui client code
 

--- a/src/ezwebframe.erl
+++ b/src/ezwebframe.erl
@@ -9,8 +9,7 @@
 	 websocket_info/3,
 	 append_div/3,
 	 pre/1,
-	 fill_div/3,
-	 start_if_not_running/1
+	 fill_div/3
 	]).
 
 -import(ezwebframe_mochijson2, [encode/1, decode/1]).


### PR DESCRIPTION
The commit's are a bit of a mess (a rebase gone haywire) but I think the changes are good.

I was testing this for my own site (not running there yet) and I found that when reltool included crypto, ezwebframe would crash since it would already have been started.

Also I created my own application using ezwebframe as a dependency and put all my html/css/js into the priv_dir. Calling for index.html didn't work that way but it works with these changes.
