### PR TITLE
Changed pattern match in receive loop

### DIFF
--- a/demos/svg/svg_pad4.erl
+++ b/demos/svg/svg_pad4.erl
@@ -254,7 +254,7 @@ f2b(F, D) ->
 
 loop(Ws, B) ->
     receive
-	{msg,Json} ->
+	{From,Json} ->
 	    io:format("Received:~p~n",[Json]),
 	    loop(Ws, B);
 	X ->


### PR DESCRIPTION
On the svg_pad4 example, each time you send a command, a bad match is reported.
