### PR TITLE
Fix response of who joined the group

### DIFF
--- a/demos/chat/chat1.erl
+++ b/demos/chat/chat1.erl
@@ -8,7 +8,7 @@ running(Browser, L) ->
     receive
 	{Browser, {struct, [{join,Who}]}} ->
 	    Browser ! [{cmd,append_div},{id,scroll}, 
-		       {txt, list_to_binary([Who, " joined the group\n"])}],
+		       {txt, list_to_binary([Who, " joined the group", "<br>"])}],
 	    L1 = [Who,"<br>"|L],
 	    Browser ! [{cmd,fill_div}, {id,users},
 		       {txt, list_to_binary(L1)}],


### PR DESCRIPTION
In current response "\n" has no influence and all text is in one line. Changing "\n" to "&lt;br&gt;" fixes that problem
